### PR TITLE
Block interferes with main display

### DIFF
--- a/templates/blocks/xmnews_block.tpl
+++ b/templates/blocks/xmnews_block.tpl
@@ -1,54 +1,54 @@
-<{foreach item=news from=$block.news}>
+<{foreach item=blocknews from=$block.news}>
 	<{if $block.full == 0}>
-	<div class="col-xs-12 col-sm-6 col-md-4 xmnews-minibox">		
+	<div class="col-xs-12 col-sm-6 col-md-4 xmnews-minibox">
 		<div class="xmnews-logo">
-			<{if $news.logo != ''}>		
-			<img src="<{$news.logo}>" alt="<{$news.title}>">
-			<{/if}>			
-		</div>		
-		<a class="xmnews-title" title="<{$news.title}>" href="<{$xoops_url}>/modules/xmnews/article.php?news_id=<{$news.id}>">
-			<{$news.title|truncate:25:'...'}>
+			<{if $blocknews.logo != ''}>
+			<img src="<{$blocknews.logo}>" alt="<{$blocknews.title}>">
+			<{/if}>
+		</div>
+		<a class="xmnews-title" title="<{$blocknews.title}>" href="<{$xoops_url}>/modules/xmnews/article.php?news_id=<{$blocknews.id}>">
+			<{$blocknews.title|truncate:25:'...'}>
 		</a>
 		<div class="row xmnews-data">
-			<{if $news.type == "date" || $news.type == "random"}>
+			<{if $blocknews.type == "date" || $blocknews.type == "random"}>
 			<div class="col-md-8"><span class="glyphicon glyphicon-calendar" title="<{$smarty.const._MA_XMNEWS_BLOCKS_DATE}>"></span>
-				<{$smarty.const._MA_XMNEWS_BLOCKS_DATE}>: <{$news.date}>
+				<{$smarty.const._MA_XMNEWS_BLOCKS_DATE}>: <{$blocknews.date}>
 			</div>
 			<{/if}>
-			<{if $news.type == "hits"}>
+			<{if $blocknews.type == "hits"}>
 			<div class="col-md-8"><span class="glyphicon glyphicon-repeat" title="<{$smarty.const._MA_XMNEWS_NEWS_READING}>"></span>
-				<{$smarty.const._MA_XMNEWS_NEWS_READING}>: <{$news.hits}>
+				<{$smarty.const._MA_XMNEWS_NEWS_READING}>: <{$blocknews.hits}>
 			</div>
 			<{/if}>
-			<{if $news.type == "rating"}>
+			<{if $blocknews.type == "rating"}>
 			<div class="col-md-8"><span class="glyphicon glyphicon-star-empty" title="<{$smarty.const._MA_XMNEWS_NEWS_RATING}>"></span>
-				<{$smarty.const._MA_XMNEWS_NEWS_RATING}>: <{$news.rating}> <{$news.votes}>
+				<{$smarty.const._MA_XMNEWS_NEWS_RATING}>: <{$blocknews.rating}> <{$blocknews.votes}>
 			</div>
 			<{/if}>
 		</div>
 
 		<div class="xmnews-short-description">
-			<{$news.description|truncateHtml:20:'...'}>
+			<{$blocknews.description|truncateHtml:20:'...'}>
 		</div>
 
-		<a class="btn btn-primary col-xs-12 col-sm-10 col-md-8" title="<{$news.title}>"
-		   href="<{$xoops_url}>/modules/xmnews/article.php?news_id=<{$news.id}>">
+		<a class="btn btn-primary col-xs-12 col-sm-10 col-md-8" title="<{$blocknews.title}>"
+		   href="<{$xoops_url}>/modules/xmnews/article.php?news_id=<{$blocknews.id}>">
 			<{$smarty.const._MA_XMNEWS_NEWS_MORE}>
 		</a>
 	</div>
 	<{else}>
     <div class="media">
         <div class="media-left">
-			<{if $news.logo != ''}>
-            <img class="media-object" src="<{$news.logo}>" alt="<{$news.title}>">
+			<{if $blocknews.logo != ''}>
+            <img class="media-object" src="<{$blocknews.logo}>" alt="<{$blocknews.title}>">
 			<{/if}>
         </div>
         <div class="media-body">
-            <h2 class="media-heading"><{$news.title}></h2>
+            <h2 class="media-heading"><{$blocknews.title}></h2>
         </div>
     </div>
 	<div>
-		<{$news.news}>
+		<{$blocknews.news}>
 	</div>
     <br>
     <div class="panel panel-default">
@@ -57,60 +57,60 @@
         </div>
         <div class="panel-body">
 			<div class="row xmnews-general">
-				<{if $news.dodate == 1}>
+				<{if $blocknews.dodate == 1}>
 				<div class="col-xs-12 col-sm-6 col-md-6"><span class="glyphicon glyphicon-calendar" title="<{$smarty.const._MA_XMNEWS_NEWS_DATE}>"></span>
-					<{$smarty.const._MA_XMNEWS_NEWS_DATE}>: <{$news.date}>
+					<{$smarty.const._MA_XMNEWS_NEWS_DATE}>: <{$blocknews.date}>
 				</div>
 				<{/if}>
-				<{if $news.douser == 1}>
+				<{if $blocknews.douser == 1}>
 				<div class="col-xs-12 col-sm-6 col-md-6"><span class="glyphicon glyphicon-user" title="<{$smarty.const._MA_XMNEWS_NEWS_AUTHOR}>"></span>
-					<{$smarty.const._MA_XMNEWS_NEWS_AUTHOR}>: <{$news.author}>
+					<{$smarty.const._MA_XMNEWS_NEWS_AUTHOR}>: <{$blocknews.author}>
 				</div>
 				<{/if}>
 			</div>
-			<{if $news.domdate == 1}>
-			<{if $news.mdate}>
+			<{if $blocknews.domdate == 1}>
+			<{if $blocknews.mdate}>
 			<div class="row xmnews-general">
 				<div class="col-xs-12 col-sm-6 col-md-6"><span class="glyphicon glyphicon-calendar" title="<{$smarty.const._MA_XMNEWS_NEWS_MDATE}>"></span>
-					<{$smarty.const._MA_XMNEWS_NEWS_MDATE}>: <{$news.mdate}>
+					<{$smarty.const._MA_XMNEWS_NEWS_MDATE}>: <{$blocknews.mdate}>
 				</div>
 			</div>
 			<{/if}>
 			<{/if}>
 			<div class="row xmnews-general">
-				<{if $news.dohits == 1}>
+				<{if $blocknews.dohits == 1}>
 				<div class="col-xs-12 col-sm-6 col-md-6"><span class="glyphicon glyphicon-repeat" title="<{$smarty.const._MA_XMNEWS_NEWS_READING}>"></span>
-					<{$smarty.const._MA_XMNEWS_NEWS_READING}>: <{$news.hits}>
+					<{$smarty.const._MA_XMNEWS_NEWS_READING}>: <{$blocknews.hits}>
 				</div>
 				<{/if}>
-				<{if $news.dorating == 1}>
+				<{if $blocknews.dorating == 1}>
 				<div class="col-xs-12 col-sm-6 col-md-6"><span class="glyphicon glyphicon-star-empty" title="<{$smarty.const._MA_XMNEWS_NEWS_RATING}>"></span>
-					<{$smarty.const._MA_XMNEWS_NEWS_RATING}>: <{$news.rating}> <{$news.votes}>
+					<{$smarty.const._MA_XMNEWS_NEWS_RATING}>: <{$blocknews.rating}> <{$blocknews.votes}>
 				</div>
 				<{/if}>
 			</div>
 			<div class="xmnews-general-button">
 				<div class="btn-group" role="group" aria-label="...">
-					<{if $news.perm_clone == true}>
-					<a href="<{$xoops_url}>/modules/xmnews/action.php?op=clone&amp;news_id=<{$news.id}>">
+					<{if $blocknews.perm_clone == true}>
+					<a href="<{$xoops_url}>/modules/xmnews/action.php?op=clone&amp;news_id=<{$blocknews.id}>">
                         <button type="button" class="btn btn-default"><span class="glyphicon glyphicon-duplicate"></span> <{$smarty.const._MA_XMNEWS_CLONE}></button>
                     </a>
 					<{/if}>
-					<{if $news.perm_edit == true}>
-                    <a href="<{$xoops_url}>/modules/xmnews/action.php?op=edit&amp;news_id=<{$news.id}>">
+					<{if $blocknews.perm_edit == true}>
+                    <a href="<{$xoops_url}>/modules/xmnews/action.php?op=edit&amp;news_id=<{$blocknews.id}>">
                         <button type="button" class="btn btn-default"><span class="glyphicon glyphicon-edit"></span> <{$smarty.const._MA_XMNEWS_EDIT}></button>
                     </a>
 					<{/if}>
-					<{if $news.perm_del == true}>
-                    <a href="<{$xoops_url}>/modules/xmnews/action.php?op=del&amp;news_id=<{$news.id}>">
+					<{if $blocknews.perm_del == true}>
+                    <a href="<{$xoops_url}>/modules/xmnews/action.php?op=del&amp;news_id=<{$blocknews.id}>">
                         <button type="button" class="btn btn-default"><span class="glyphicon glyphicon-remove"></span> <{$smarty.const._MA_XMNEWS_DEL}></button>
                     </a>
 					<{/if}>
 				</div>
 			</div>
-			
+
         </div>
-    </div>	
+    </div>
 	<{/if}>
 <{/foreach}>
 <div class="clearfix"></div>

--- a/templates/blocks/xmnews_block_waiting.tpl
+++ b/templates/blocks/xmnews_block_waiting.tpl
@@ -8,13 +8,13 @@
 		</tr>
 	</thead>
 	<tbody>
-<{foreach item=news from=$block.news}>
+<{foreach item=waitingnews from=$block.news}>
 	<tr>
-		<td><{$news.title}></td>
-		<td><{$news.description|truncateHtml:50:'...'}></td>
-		<td><{$news.author}></td>
+		<td><{$waitingnews.title}></td>
+		<td><{$waitingnews.description|truncateHtml:50:'...'}></td>
+		<td><{$waitingnews.author}></td>
 		<td>
-			<a href="<{$xoops_url}>/modules/xmnews/action.php?op=edit&amp;news_id=<{$news.id}>">
+			<a href="<{$xoops_url}>/modules/xmnews/action.php?op=edit&amp;news_id=<{$waitingnews.id}>">
 				<button type="button" class="btn btn-default"><span class="glyphicon glyphicon-edit"></span> <{$smarty.const._MA_XMNEWS_EDIT}></button>
 			</a>
 		</td>


### PR DESCRIPTION
If an xmnews block is used in the xmnews module display corruption can occur. The smarty $news variable intended for the module level display is changed in the block templates, as a foreach item.

![Screenshot from 2020-02-08 14-17-57](https://user-images.githubusercontent.com/3181636/74091721-211c6600-4a80-11ea-8609-68c7a767ace4.png)
