### PR TITLE
Update xmnews_block_waiting.tpl

### DIFF
--- a/extra/Templates for bootstrap 4/xmnews/blocks/xmnews_block_waiting.tpl
+++ b/extra/Templates for bootstrap 4/xmnews/blocks/xmnews_block_waiting.tpl
@@ -1,28 +1,26 @@
 <{if $block.news != ''}>
-<div class="table-responsive">
-	<table class="table table-hover table-sm">
-	<thead>
-		<tr>
-			<th scope="col"><{$smarty.const._MA_XMNEWS_NEWS_TITLE}></th>
-			<th class="d-none d-sm-table-cell" scope="col"><{$smarty.const._MA_XMNEWS_NEWS_DESC}></th>
-			<th scope="col" class="text-center"><{$smarty.const._MA_XMNEWS_NEWS_USERID}></th>
-			<th scope="col" class="text-center"><{$smarty.const._MA_XMNEWS_ACTION}></th>
-		</tr>
-	</thead>
-	<tbody>
-<{foreach item=waitingnews from=$block.news}>
-	<tr>
-		<td class=""><{$waitingnews.title}></td>
-		<td class="d-none d-sm-table-cell"><{$waitingnews.description|truncateHtml:50:'...'}></td>
-		<td class="text-center"><{$waitingnews.author}></td>
-		<td class="text-center">
-			<a class="btn btn-outline-primary" title="<{$smarty.const._MA_XMNEWS_EDIT}>" href="<{$xoops_url}>/modules/xmnews/action.php?op=edit&amp;news_id=<{$waitingnews.id}>"><i class="fa fa-edit" aria-hidden="true"></i></a>
-		</td>
-	</tr>
-<{/foreach}>
-	</tbody>
-</table>
-</div>
+	<table class="table table-striped table-hover table-sm">
+		<thead class="bg-warning">
+			<tr>
+				<th class="text-center" scope="col"><{$smarty.const._MA_XMNEWS_NEWS_TITLE}></th>
+				<th class="text-center d-none d-md-table-cell" scope="col"><{$smarty.const._MA_XMNEWS_NEWS_DESC}></th>
+				<th class="text-center" scope="col"><{$smarty.const._MA_XMNEWS_NEWS_USERID}></th>
+				<th class="text-center" scope="col"><{$smarty.const._MA_XMNEWS_ACTION}></th>
+			</tr>
+		</thead>
+		<tbody>
+		<{foreach item=waitingnews from=$block.news}>
+			<tr>
+				<td class="text-sm-center text-warning text-nowrap"><{$waitingnews.title}></td>
+				<td class="d-none d-md-block text-warning"><{$waitingnews.description|truncateHtml:50:'...'}></td>
+				<td class="text-center text-warning text-nowrap"><{$waitingnews.author}></td>
+				<td>
+					<a class="btn btn-outline-primary text-warning text-center" title="<{$smarty.const._MA_XMNEWS_EDIT}>" href="<{$xoops_url}>/modules/xmnews/action.php?op=edit&amp;news_id=<{$waitingnews.id}>"><i class="fas fa-edit" aria-hidden="true"></i></a>
+				</td>
+			</tr>
+		<{/foreach}>
+		</tbody>
+	</table>
 <{else}>
-	<div class="alert alert-warning"><{$smarty.const._MA_XMNEWS_BLOCKS_NOWAITING}></div>
+	<div class="alert alert-primary"><{$smarty.const._MA_XMNEWS_BLOCKS_NOWAITING}></div>
 <{/if}>


### PR DESCRIPTION
- Ajout de table-hover
- Description disparaît sous largeur md maintenant (avant, c'était sm)
- Centrage de tout sauf description
- Texte en couleur Warning
- Fond titre en couleur warning
- Ajout de nowrap pour titre et auteur, c'est + clair
- Message "pas d'article en attente" moins voyant (il faut que cela soit bien voyant si article en attente seulement)